### PR TITLE
Fixed an issue with module loading.

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,11 +1,13 @@
 <?php
 
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
-use SilverStripe\Core\Manifest\ModuleResourceLoader;
+use SilverStripe\Core\Manifest\ModuleLoader;
+
+// Parse out the composer package name, and load the module using SilverStripe.
+$package = json_decode(file_get_contents(__DIR__.'/composer.json'));
+$module = ModuleLoader::getModule($package->name);
 
 // Enable the Webfont TinyMCE plugin by default.
 HtmlEditorConfig::get('cms')->enablePlugins([
-    'webfonts' => ModuleResourceLoader::singleton()->resolvePath(
-        'gorriecoe/silverstripe-webfonts: assets/js/tinymce.webfontsdummy.js'
-    )
+    'webfonts' => $module->getResource('assets/js/tinymce.webfontsdummy.js')
 ]);


### PR DESCRIPTION
Hey Gorrie, hope you're doing well 😃. 

No rush at all to look at this, but I found that the path to the dummy webfonts js file in the auto generated `assets/_tinymce/tinymce-cms-11785eb912.js` file, didn't have `resources` prefixed to the vendor path, giving load errors.

List of changes:

+ Replaced ModuleResourceLoader with ModuleLoader. This corrects the public path to the `tinymce.webfontsdummy.js` file in the generated tinymce js file.
+ Package name is now parsed out of the composer.json file.

I'm by no means a SS expert, so feel free to edit what I've done!